### PR TITLE
fix: update black from 20.8b1 to 22.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django~=3.1
 pylint-django==2.2.0
 mypy==0.782
-black==20.8b1
+black==22.3.0
 isort==5.5.2
 pylint==2.6.0


### PR DESCRIPTION
Otherwise black fails with the following error message

    Running black
    Traceback (most recent call last):
      File "/usr/local/bin/black", line 8, in <module>
         sys.exit(patched_main())
      File "/usr/local/lib/python3.8/site-packages/black/__init__.py", line 6606, in patched_main
         patch_click()
      File "/usr/local/lib/python3.8/site-packages/black/__init__.py", line 6595, in patch_click
        from click import _unicodefun  # type: ignore
    ImportError: cannot import name '_unicodefun' from 'click' (/usr/local/lib/python3.8/site-packages/click/__init__.py)

See https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click