### PR TITLE
fix: enable globstar

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s globstar
 
 # source = $1
 # strict = $2


### PR DESCRIPTION
`entrypoint.sh` uses  globstar in the `isort` call.